### PR TITLE
修复运行时报错

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,7 +1,12 @@
 // @flow
 
 import './App/Config/ReactotronConfig'
-import { AppRegistry } from 'react-native'
-import App from './App/Containers/App'
+import ReactNative, { AppRegistry, View } from 'react-native'
+
+// 兼容 0.39 版本的支持
+ReactNative.ViewPropTypes || ( ReactNative.ViewPropTypes = View.propTypes );
+ReactNative.BackHandler || ( ReactNative.BackHandler = ReactNative.BackAndroid );
+
+let App = require( './App/Containers/App' ).default;
 
 AppRegistry.registerComponent('app', () => App)

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,7 +1,12 @@
 // @flow
 
 import './App/Config/ReactotronConfig'
-import { AppRegistry } from 'react-native'
-import App from './App/Containers/App'
+import ReactNative, { AppRegistry, View } from 'react-native'
+
+// 兼容 0.39 版本的支持
+ReactNative.ViewPropTypes || ( ReactNative.ViewPropTypes = View.propTypes );
+ReactNative.BackHandler || ( ReactNative.BackHandler = ReactNative.BackAndroid );
+
+let App = require( './App/Containers/App' ).default;
 
 AppRegistry.registerComponent('app', () => App)


### PR DESCRIPTION
运行时，发现是因为依赖包react-native-router-flux 版本和现有的react-native 版本不兼容的问题。

这个依赖包react-native-router-flux的版本使用到了 ViewPropTypes、BackHandler， 而这个demo使用的react-native 版本是 0.39，还没有ViewPropTypes、BackHandler... 

所以这个 pull request 做了一些兼容性处理
